### PR TITLE
EX-12383 - Fix for PHP 8.4 on ResponseException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/Nuvei/nuvei-server-php",
   "license": "MIT",
   "require": {
-    "php": ">=5.4",
+    "php": "^8.1|^8.4",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/src/Nuvei/Api/Exception/NuveiException.php
+++ b/src/Nuvei/Api/Exception/NuveiException.php
@@ -20,7 +20,7 @@ class NuveiException extends Exception
      * @param Exception|null $previous
      * @param null $status
      */
-    public function __construct($message = "", $code = 0, Exception $previous = null, $status = null)
+    public function __construct($message = "", $code = 0, ?Exception $previous = null, $status = null)
     {
         $this->_status = $status;
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
This PR:
- update `composer.json` to use php 8.1=>8.4;
- update the `NuveiException` for explicit nullable param.